### PR TITLE
Add a YAML FrontMatter metadata parser

### DIFF
--- a/lib/pardall_markdown/metadata_parser/yaml.ex
+++ b/lib/pardall_markdown/metadata_parser/yaml.ex
@@ -1,0 +1,51 @@
+defmodule PardallMarkdown.MetadataParser.Yaml do
+  import YamlElixir, only: [read_from_string: 2]
+  @behaviour PardallMarkdown.MetadataParser
+
+  @default_metadata_parser PardallMarkdown.MetadataParser.ElixirMap
+
+  def parse(path, contents, opts) do
+    is_index? = Keyword.get(opts, :is_index?, false)
+
+    yaml_config =
+      Application.get_env(
+        :pardall_markdown,
+        PardallMarkdown.MetadataParser.Yaml
+      ) || [metadata_parser_after_title: @default_metadata_parser]
+
+    parser = Keyword.get(yaml_config, :metadata_parser_after_title, @default_metadata_parser)
+
+    do_parse = fn split_contents ->
+      apply(parser, :parse, [path, split_contents, opts])
+    end
+
+    # REVIEW: Matches pattern used in ElixirMap
+    # Perhaps there is a better patter to split on that won't
+    # run interference to the parsing after the metadata?
+    case :binary.split(contents, ["\n---\n", "\r\n---\r\n"]) do
+      [_] ->
+        do_parse.(contents)
+
+      [_, contents] when is_index? ->
+        do_parse.(contents)
+
+      [yaml_string, contents] ->
+        case read_from_string(yaml_string, atoms: true) do
+          {:ok, frontmatter} ->
+            # REVIEW: I get a nastygram if I don't prefix with \n---\n from ElixirMap.
+            case do_parse.("\n---\n#{contents}") do
+              {:ok, _attrs, body} ->
+                # REVIEW: Represents [code, body] in ElixirMap
+                {:ok, frontmatter, body}
+
+              other ->
+                other
+            end
+
+          other ->
+            {:error,
+             "oops, I don't think you have YAML present or you reached for the wrong parser: #{inspect(other)}"}
+        end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule PardallMarkdown.MixProject do
       {:con_cache, "~> 0.13"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:git_cli, "~> 0.3"},
+      {:yaml_elixir, "~> 2.8"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -18,4 +18,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "slugify": {:hex, :slugify, "1.3.1", "0d3b8b7e5c1eeaa960e44dce94382bee34a39b3ea239293e457a9c5b47cc6fd3", [:mix], [], "hexpm", "cb090bbeb056b312da3125e681d98933a360a70d327820e4b7f91645c4d8be76"},
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
+  "yamerl": {:hex, :yamerl, "0.8.1", "07da13ffa1d8e13948943789665c62ccd679dfa7b324a4a2ed3149df17f453a4", [:rebar3], [], "hexpm", "96cb30f9d64344fed0ef8a92e9f16f207de6c04dfff4f366752ca79f5bceb23f"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.8.0", "c7ff0034daf57279c2ce902788ce6fdb2445532eb4317e8df4b044209fae6832", [:mix], [{:yamerl, "~> 0.8", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "4b674bd881e373d1ac6a790c64b2ecb69d1fd612c2af3b22de1619c15473830b"},
 }


### PR DESCRIPTION
## What does this PR do?

- adds `yaml.ex` for users to use as a metadata parser when they prefer to use YAML syntax for their front matter.

Closes #41 